### PR TITLE
feat: support for environment variables and layers within gatsby func…

### DIFF
--- a/examples/cdk-project/bin/cdk.ts
+++ b/examples/cdk-project/bin/cdk.ts
@@ -32,4 +32,4 @@ const env: cdk.Environment = {
 /**
  * Deploy Gatsby.
  */
-new GatsbyStack(app, "gatsby", { env, gatsbyDir: "../../examples/ssr" });
+new GatsbyStack(app, "gatsby", { env, gatsbyDir: "../../examples/gatsby-functions" });

--- a/examples/cdk-project/lib/stacks/gatsby.ts
+++ b/examples/cdk-project/lib/stacks/gatsby.ts
@@ -37,6 +37,17 @@ export class GatsbyStack extends cdk.Stack {
     new GatsbySite(this, "GatsbySite", {
       cluster,
       gatsbyDir,
+      gatsbyFunctionOptions: () => {
+        return {
+          target: "LAMBDA",
+          environmentVars: {
+            test: "envvalue",
+          },
+          lambdaLayerArns: [
+            "arn:aws:lambda:ap-southeast-2:665172237481:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11",
+          ],
+        };
+      },
       distribution: { cachePolicy },
       ssrOptions: ssr ? { target: ssr } : undefined,
     });

--- a/src/cdk/GatsbySite.ts
+++ b/src/cdk/GatsbySite.ts
@@ -153,6 +153,15 @@ export class GatsbySite extends Construct {
             runtime: lambda.Runtime.NODEJS_18_X,
             code: lambda.Code.fromAsset(fn.functionDir),
             insightsVersion: lambda.LambdaInsightsVersion.VERSION_1_0_229_0,
+            environment: options.environmentVars || {},
+            layers:
+              options.lambdaLayerArns?.map((arn, index) =>
+                lambda.LayerVersion.fromLayerVersionArn(
+                  this,
+                  fn.functionId + index,
+                  arn,
+                ),
+              ) || [],
           },
         );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,14 @@ export type GatsbyFunctionOptionsLambda = {
    * Provisioned concurrency configuration for the alias.
    */
   provisionedConcurrentExecutions?: lambda.AliasOptions["provisionedConcurrentExecutions"];
+  /**
+   * Environment variables to set within a lambda
+   */
+  environmentVars?: lambda.FunctionOptions["environment"];
+  /**
+   * Lambda layer ARNs to set externsions
+   */
+  lambdaLayerArns?: string[];
 };
 
 export type GatsbyFunctionOptionsFargate = {


### PR DESCRIPTION
This PR aims to add 2 features to this library:
- Ability to add environment variables to Gatsby Lambda Functions
- Ability to add lambda layers to Gatsby Lambda Functions

The code has been updated in the example directory to provide a sample for functions. 
```
environmentVars: {
  test: "envvalue",
},
lambdaLayerArns: [
  "arn:aws:lambda:ap-southeast-2:665172237481:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11",
],
```