### PR TITLE
feat: allow all http methods for function apis

### DIFF
--- a/src/cdk/GatsbyDistribution.ts
+++ b/src/cdk/GatsbyDistribution.ts
@@ -217,6 +217,8 @@ export class GatsbyDistribution extends Construct {
               // Default attributes.
               cachePolicy,
               viewerProtocolPolicy,
+              // Allow all methods for Gatsby function APIs
+              allowedMethods: cloudfront.CloudFrontAllowedMethods.ALL,
               // User attributes.
               ...cacheBehaviorOptions?.functions,
               // Protected attributes.


### PR DESCRIPTION
Allow all methods when configuring CloudFront behaviour for the Gatsby function API. The default behaviour is only to allow GET and HEAD. This change allows function API to manage method level allow and deny.