### PR TITLE
feat: allow query params to reach gatsby functions

### DIFF
--- a/src/cdk/GatsbyDistribution.ts
+++ b/src/cdk/GatsbyDistribution.ts
@@ -222,6 +222,8 @@ export class GatsbyDistribution extends Construct {
               // User attributes.
               ...cacheBehaviorOptions?.functions,
               // Protected attributes.
+              originRequestPolicy:
+                cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
               origin:
                 "LAMBDA" === gatsbyFunction.target
                   ? new origins.HttpOrigin(


### PR DESCRIPTION
With the current setup, Cloudfront strips any query parameters in the URL from reaching the lambda function. This MR sets the Origin request policy to forward all parameters.

<img width="593" alt="Screenshot 2024-03-12 at 4 27 49 pm" src="https://github.com/dangreaves/gatsby-adapter-aws/assets/5582062/5216f911-d50c-46af-8e74-a87ad58c0585">
